### PR TITLE
Bugfix/Change-textarea-autosize-version

### DIFF
--- a/.changeset/proud-horses-return.md
+++ b/.changeset/proud-horses-return.md
@@ -1,0 +1,5 @@
+---
+'@seed-ui/elements': patch
+---
+
+Changed react-textarea-autosize version to make it work well with SSR.

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "@seed-ui/styles": "^0.3.3",
     "@seed-ui/icons": "^0.3.6",
-    "@seed-ui/layout": "^0.3.5",
+    "@seed-ui/layout": "^0.3.6",
     "@vanilla-extract/sprinkles": "^1.3.0",
     "classnames": "^2.3.1",
     "hex-to-rgba": "^2.0.1",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -85,6 +85,6 @@
     "classnames": "^2.3.1",
     "hex-to-rgba": "^2.0.1",
     "lodash": "^4.17.21",
-    "react-textarea-autosize": "^8.3.3"
+    "react-textarea-autosize": "^7.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1105,6 +1105,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.1.2":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.0.tgz#e27b977f2e2088ba24748bf99b5e1dece64e4f0b"
+  integrity sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.13", "@babel/template@^7.12.7", "@babel/template@^7.15.4", "@babel/template@^7.3.3":
   version "7.15.4"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz"
@@ -13289,7 +13296,15 @@ react-syntax-highlighter@^13.5.3:
     prismjs "^1.21.0"
     refractor "^3.1.0"
 
-react-textarea-autosize@^8.3.0, react-textarea-autosize@^8.3.3:
+react-textarea-autosize@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-7.1.2.tgz#70fdb333ef86bcca72717e25e623e90c336e2cda"
+  integrity sha512-uH3ORCsCa3C6LHxExExhF4jHoXYCQwE5oECmrRsunlspaDAbS4mGKNlWZqjLfInWtFQcf0o1n1jC/NGXFdUBCg==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    prop-types "^15.6.0"
+
+react-textarea-autosize@^8.3.0:
   version "8.3.3"
   resolved "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz"
   integrity sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==


### PR DESCRIPTION
## Bugfix/Change-textarea-autosize-version

Changed react-textarea-autosize version to make it work well with SSR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
