### PR TITLE
Bugfix/remove textarea autosize

### DIFF
--- a/.changeset/nice-needles-rescue.md
+++ b/.changeset/nice-needles-rescue.md
@@ -1,0 +1,5 @@
+---
+'@seed-ui/elements': patch
+---
+
+Removed react-textarea-autosize package.

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -49,7 +49,6 @@
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.8.3",
     "@types/jest": "^26.0.23",
-    "@types/react-textarea-autosize": "^4.3.6",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "@vanilla-extract/babel-plugin": "^1.1.1",
@@ -80,11 +79,10 @@
   "dependencies": {
     "@seed-ui/styles": "^0.3.3",
     "@seed-ui/icons": "^0.3.6",
-    "@seed-ui/layout": "^0.3.5",
+    "@seed-ui/layout": "^0.3.6",
     "@vanilla-extract/sprinkles": "^1.3.0",
     "classnames": "^2.3.1",
     "hex-to-rgba": "^2.0.1",
-    "lodash": "^4.17.21",
-    "react-textarea-autosize": "^8.3.3"
+    "lodash": "^4.17.21"
   }
 }

--- a/packages/elements/src/components/Textarea/Textarea.tsx
+++ b/packages/elements/src/components/Textarea/Textarea.tsx
@@ -1,7 +1,4 @@
 import React from 'react';
-import TextareaAutosize, {
-  TextareaAutosizeProps,
-} from 'react-textarea-autosize';
 import cx from 'classnames';
 
 import { InputContainer } from '../InputGroup/InputContainer';
@@ -18,7 +15,10 @@ export type TextareaShape = 'rectangle' | 'stadium';
 export type TextareaSize = 'sm' | 'md' | 'lg';
 
 export interface TextareaProps
-  extends Omit<TextareaAutosizeProps, 'ref' | 'size' | 'action' | 'label'> {
+  extends Omit<
+    React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+    'size' | 'action' | 'label'
+  > {
   label?: React.ReactNode;
   submitOnEnter?: boolean;
   shape?: TextareaShape;
@@ -103,7 +103,7 @@ const Textarea = (
         shape={shape}
         size={size}
       >
-        <TextareaAutosize
+        <textarea
           {...inputProps}
           className={cx(textboxStyle, S.textarea)}
           id={id}


### PR DESCRIPTION
## Bugfix/remove textarea autosize

Removed react-textarea-autosize package.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
