### PR TITLE
Bugfix: Remove global css import from icon component

### DIFF
--- a/.changeset/many-files-compete.md
+++ b/.changeset/many-files-compete.md
@@ -1,0 +1,5 @@
+---
+'@seed-ui/icons': patch
+---
+
+Removed global css import from icon component.

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,6 +4,7 @@ import { withPerformance } from 'storybook-addon-performance';
 import { withThemes } from 'storybook-addon-themes/react';
 import { theme as vars } from '@seed-ui/styles'
 import { theme, components, sortStories } from './utils';
+import 'boxicons/css/boxicons.min.css';
 
 const SORT_ORDER = {
   'Overview': {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -42,7 +42,8 @@
   "author": "Sergey Murawsky",
   "license": "MIT",
   "peerDependencies": {
-    "@vanilla-extract/css": "^1.6.1"
+    "@vanilla-extract/css": "^1.6.1",
+    "boxicons": "^2.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
@@ -59,6 +60,7 @@
     "babel-jest": "^26.6.3",
     "babel-plugin-inline-react-svg": "^2.0.1",
     "babel-plugin-lodash": "^3.3.4",
+    "boxicons": "^2.1.2",
     "cross-env": "^7.0.3",
     "esbuild": "^0.13.3",
     "esbuild-plugin-babel": "^0.2.3",
@@ -79,8 +81,7 @@
     "typescript": "4.2.2"
   },
   "dependencies": {
-    "@seed-ui/styles": "^0.3.10",
-    "boxicons": "^2.1.2",
+    "@seed-ui/styles": "^0.3.11",
     "classnames": "^2.3.1"
   }
 }

--- a/packages/icons/src/components/Icon/Icon.tsx
+++ b/packages/icons/src/components/Icon/Icon.tsx
@@ -1,7 +1,6 @@
 import React, { HTMLAttributes } from 'react';
 import cn from 'classnames';
 
-import 'boxicons/css/boxicons.min.css';
 import { Maybe } from '../../types/helpers';
 
 import * as S from './Icon.css';


### PR DESCRIPTION
## Description

Removed global css import from icon component.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
