### PR TITLE
fix: Unset a:visible styles by default

### DIFF
--- a/.changeset/great-oranges-smash.md
+++ b/.changeset/great-oranges-smash.md
@@ -1,0 +1,5 @@
+---
+'@seed-ui/styles': patch
+---
+
+Unset a:visible styles by default.

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,6 +15,9 @@ coverage:
     default_rules:
       flag_coverage_not_uploaded_behavior: include
     patch: false
-    project: true
+    project:
+      default:
+        target: 60%
+        removed_code_behavior: adjust_base
 github_checks:
   annotations: true

--- a/packages/styles/src/styles/global.css.ts
+++ b/packages/styles/src/styles/global.css.ts
@@ -45,14 +45,11 @@ globalStyle('a', {
   color: vars.color.primary500,
   cursor: 'pointer',
   textDecoration: 'none',
+  transition: vars.transition.base,
 });
 
 globalStyle('a:hover', {
   textDecoration: 'underline',
-});
-
-globalStyle('a:visited', {
-  color: vars.color.secondary500,
 });
 
 globalStyle('button', {


### PR DESCRIPTION
## Description

Unset a:visible styles by default. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
